### PR TITLE
Disable auth on callback path

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,11 +14,14 @@ exports.register = function(plugin, options, next) {
     // NOTE: needs to be '*'
     method: '*',
     path: path,
-    handler: function(request, reply) {
-      plugin.log(['debug', 'callback'], JSON.stringify(request.auth));
+    config: {
+      auth: false,
+      handler: function(request, reply) {
+        plugin.log(['debug', 'callback'], JSON.stringify(request.auth));
 
-      // Run authentication
-      samlHapi.authenticate(settings)(request, reply);
+        // Run authentication
+        samlHapi.authenticate(settings)(request, reply);
+      }
     }
   });
 


### PR DESCRIPTION
This explicitly disables authentication on the callback.

We ran into some errors when using `server.auth.default('...')` because that sets authentication on every path. This PR allows you to use `server.auth.default('...')` again :)
